### PR TITLE
V1.8.10

### DIFF
--- a/victoria-metrics/CHANGELOG.md
+++ b/victoria-metrics/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.8.10
 
 - Updated documentation and added Grafana tips
-- Replace binary from docker image victoriametrics/victoria-metrics:v1.81.2 with official build https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v1.81.2/victoria-metrics-darwin-amd64-v1.81.2.tar.gz
+- Replace binary from docker image victoriametrics/victoria-metrics:v1.81.2 with official build https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v1.81.2/victoria-metrics-darwin-arm64-v1.81.2.tar.gz
 
 ## 1.8.9
 

--- a/victoria-metrics/CHANGELOG.md
+++ b/victoria-metrics/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.8.10
 
 - Updated documentation and added Grafana tips
-- Replace binary from docker image victoriametrics/victoria-metrics:v1.81.2 with official build https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v1.81.2/victoria-metrics-darwin-arm64-v1.81.2.tar.gz
+- Replace binary from docker image victoriametrics/victoria-metrics:v1.81.2 with official build https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v1.81.2/victoria-metrics-linux-arm-v1.81.2.tar.gz
 
 ## 1.8.9
 

--- a/victoria-metrics/CHANGELOG.md
+++ b/victoria-metrics/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.8.10
 
 - Updated documentation and added Grafana tips
+- Replace binary from docker image victoriametrics/victoria-metrics:v1.81.2 with official build https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v1.81.2/victoria-metrics-darwin-amd64-v1.81.2.tar.gz
 
 ## 1.8.9
 


### PR DESCRIPTION
- Updated documentation and added Grafana tips
- Replace binary from docker image victoriametrics/victoria-metrics:v1.81.2 with official build