### PR TITLE
Add Ingress and update

### DIFF
--- a/victoria-metrics/DOCS.md
+++ b/victoria-metrics/DOCS.md
@@ -42,7 +42,7 @@ With the option `measurement_attr: entity_id` you will get the `entity_id` as me
 ```yml
 influxdb:
   api_version: 1
-  host: <<<YOUR LOCAL HOME ASSISTANT IP>>>
+  host: <<<ADD-ON HOSTNAME FROM ADD-ON PAGE>>>
   port: 8428
   max_retries: 3
   measurement_attr: entity_id

--- a/victoria-metrics/Dockerfile
+++ b/victoria-metrics/Dockerfile
@@ -5,7 +5,7 @@ FROM $BUILD_FROM
 COPY start-victoria-metrics /
 COPY prometheus.yml /
 WORKDIR /share/victoria-metrics-data
-ARG VERSION=v1.86.1
+ARG VERSION=v1.86.2
 
 RUN /bin/bash -c 'set -ex && \
     ARCH=$(uname -m) && \

--- a/victoria-metrics/config.yaml
+++ b/victoria-metrics/config.yaml
@@ -3,8 +3,9 @@ version: "1.8.15"
 slug: victoria_metrics
 description: Victoria Metrics Time Series Database add-on for long term storage as replacement for Prometheus and InfluxDB
 webui: "http://[HOST]:[PORT:8428]/"
-# ingress: true
-# ingress_port: 8428
+ingress: true
+ingress_port: 8428
+ingress_entry: /vmui
 # host_network: true
 ports:
   8428/tcp: 8428


### PR DESCRIPTION
Updated to version 1.86.2

Added Ingress functionality so that we use the built in features from HA on how to reach the add-on web-pages. Also set the starting URL to /vmui to get to the Victoria Metrics GUI.

Works here for me, might need better text in documentation on how to use in HA-config. Look it over and see what you think.