### PR TITLE
Add support for Prometheus scraping job parameters

### DIFF
--- a/victoria-metrics/config.yaml
+++ b/victoria-metrics/config.yaml
@@ -1,5 +1,5 @@
 name: Victoria Metrics add-on
-version: "1.8.17"
+version: "1.8.18"
 slug: victoria_metrics
 description: Victoria Metrics Time Series Database add-on for long term storage as replacement for Prometheus and InfluxDB
 webui: "http://[HOST]:[PORT:8428]/"

--- a/victoria-metrics/config.yaml
+++ b/victoria-metrics/config.yaml
@@ -26,6 +26,8 @@ options:
   password: ""
   enablePrometheusScrape: false
   prometheusScrapeHTTPS: false
+  prometheusScrapeInterval: "20s"
+  prometheusScrapeTimeout: "15s"
   longelivedToken: ""
   homeassistantUrl: ""
 schema:
@@ -36,5 +38,7 @@ schema:
   password: "password?"
   enablePrometheusScrape: bool
   prometheusScrapeHTTPS: bool
+  prometheusScrapeInterval: "str?"
+  prometheusScrapeTimeout: "str?"
   longelivedToken: "password?"
   homeassistantUrl: "str?"

--- a/victoria-metrics/prometheus.tpl
+++ b/victoria-metrics/prometheus.tpl
@@ -4,10 +4,11 @@ global:
 
 scrape_configs:
   - job_name: "home-assistant"
-    scrape_interval: 20s
+    scrape_interval: "{{.prometheusScrapeInterval}}"
+    scrape_timeout: "{{.prometheusScrapeTimeout}}"
     metrics_path: /api/prometheus
     authorization:
       credentials: "{{.token}}"
     scheme: {{.scheme}}
     static_configs:
-      - targets: ['{{.homeassistanturl}}']
+      - targets: ['{{.homeassistantUrl}}']

--- a/victoria-metrics/start-victoria-metrics
+++ b/victoria-metrics/start-victoria-metrics
@@ -21,7 +21,7 @@ then
     then
         SCHEME="https"
     fi
-    echo '{"token": "'$(bashio::config 'longelivedToken')'", "scheme": "'$SCHEME'", "homeassistanturl": "'$(bashio::config 'homeassistantUrl')'"}' | tempio -template /prometheus.tpl -out /prometheus.yml
+    echo '{"token": "'$(bashio::config 'longelivedToken')'", "scheme": "'$SCHEME'", "homeassistantUrl": "'$(bashio::config 'homeassistantUrl')'", "prometheusScrapeInterval": "'$(bashio::config 'prometheusScrapeInterval')'", "prometheusScrapeTimeout": "'$(bashio::config 'prometheusScrapeTimeout')'"}' | tempio -template /prometheus.tpl -out /prometheus.yml
     PROMETHEUSARGS="-promscrape.config /prometheus.yml"
 fi
 

--- a/victoria-metrics/translations/de.yaml
+++ b/victoria-metrics/translations/de.yaml
@@ -21,11 +21,11 @@ configuration:
     name: Benutze HTTPS Prometheus scrape
     description: Wenn aktiv, wird für die Verbindung zu Home Assistant HTTPS benutzt.
   prometheusScrapeInterval:
-    name: TODO
-    description: TODO
+    name: Prometheus scraping interval
+    description: Legt fest, wie häufig Daten von Home Assistant abgefragt werden (z. B. "20s").
   prometheusScrapeTimeout:
-    name: TODO
-    description: TODO
+    name: Prometheus scraping timeout
+    description:  Timeout für die Abfragen der Daten von Home Assistant (z. B. "15s").
   longelivedToken:
     name: Long-lived access token
     description: Long-lived access für den Prometheus scrape (hat keinen Effekt, wenn Prometheus scrape nicht aktiviert ist).

--- a/victoria-metrics/translations/de.yaml
+++ b/victoria-metrics/translations/de.yaml
@@ -20,6 +20,12 @@ configuration:
   prometheusScrapeHTTPS:
     name: Benutze HTTPS Prometheus scrape
     description: Wenn aktiv, wird für die Verbindung zu Home Assistant HTTPS benutzt.
+  prometheusScrapeInterval:
+    name: TODO
+    description: TODO
+  prometheusScrapeTimeout:
+    name: TODO
+    description: TODO
   longelivedToken:
     name: Long-lived access token
     description: Long-lived access für den Prometheus scrape (hat keinen Effekt, wenn Prometheus scrape nicht aktiviert ist).

--- a/victoria-metrics/translations/en.yaml
+++ b/victoria-metrics/translations/en.yaml
@@ -20,6 +20,12 @@ configuration:
   prometheusScrapeHTTPS:
     name: Use HTTPS Prometheus scrape
     description: Set to true if you use a HTTPS connection for your Home Assistant.
+  prometheusScrapeInterval:
+    name: Prometheus scraping interval
+    description: How frequently to scrape Home Assistant target (example "20s").
+  prometheusScrapeTimeout:
+    name: Prometheus scraping timeout
+    description: Timeout when scraping Home Assistant target (example "15s").
   longelivedToken:
     name: Long-lived access token
     description: Long-lived access token for Prometheus scrape (has no effect if Prometheus scrape is not enabled).


### PR DESCRIPTION
This change introduces new `prometheusScrapeXXX` template variables allowing users to override Prometheus scraping parameters such as interval and timeout.

Additionally, this fixes a minor inconsistency in the naming of the `homeassistantUrl` template parameter (referenced as `homeassistanturl` in the `start-victoria-metrics` script).